### PR TITLE
Skipchain unit tests

### DIFF
--- a/blockchain/roster.go
+++ b/blockchain/roster.go
@@ -18,7 +18,7 @@ type SimpleRoster struct {
 func NewRoster(verifier crypto.Verifier, conodes ...*Conode) (SimpleRoster, error) {
 	pubkeys := make([]crypto.PublicKey, len(conodes))
 	for i, conode := range conodes {
-		pubkey, err := verifier.GetPublicKeyFactory().FromAny(conode.GetPublicKey())
+		pubkey, err := verifier.GetPublicKeyFactory().FromProto(conode.GetPublicKey())
 		if err != nil {
 			return SimpleRoster{}, err
 		}

--- a/blockchain/skipchain/block.go
+++ b/blockchain/skipchain/block.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	fmt "fmt"
-	math "math"
 
 	proto "github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -244,10 +243,11 @@ type Chain []SkipBlock
 
 // GetProof returns a verifiable proof of the latest block of the chain.
 func (c Chain) GetProof() Proof {
-	numForwardLink := int(math.Max(0, float64(len(c)-1)))
 	if len(c) == 0 {
 		return Proof{}
 	}
+
+	numForwardLink := len(c) - 1
 
 	proof := Proof{
 		GenesisBlock: c[0],
@@ -326,7 +326,7 @@ func (p Proof) Verify(v crypto.Verifier, block SkipBlock) error {
 	}
 
 	if !bytes.Equal(prev, block.GetID()) {
-		return xerrors.Errorf("got forward link to %v but expect %v", prev, block.GetID())
+		return xerrors.Errorf("got forward link to '%v' but expected '%v'", prev, block.GetID())
 	}
 
 	return nil
@@ -339,7 +339,7 @@ func (p Proof) verifyLink(v crypto.Verifier, pubkeys []crypto.PublicKey, link Fo
 	}
 
 	if !bytes.Equal(prev, link.GetFrom()) {
-		return xerrors.Errorf("got previous block %v but expect %v in forward link",
+		return xerrors.Errorf("got previous block '%v' but expected '%v' in forward link",
 			link.GetFrom(), prev)
 	}
 

--- a/blockchain/skipchain/block_test.go
+++ b/blockchain/skipchain/block_test.go
@@ -1,0 +1,429 @@
+package skipchain
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	fmt "fmt"
+	"io"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	any "github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/fabric/blockchain"
+	"go.dedis.ch/fabric/crypto"
+	"go.dedis.ch/fabric/encoding"
+	"go.dedis.ch/fabric/mino"
+	"golang.org/x/xerrors"
+)
+
+func TestBlockID_String(t *testing.T) {
+	f := func(buffer []byte) bool {
+		id := BlockID(buffer)
+
+		return id.String() == fmt.Sprintf("%x", buffer)
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func TestSkipBlock_GetID(t *testing.T) {
+	f := func(hash []byte) bool {
+		block := SkipBlock{
+			hash: hash,
+		}
+
+		return bytes.Equal(block.GetID(), hash)
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func TestSkipBlock_Pack(t *testing.T) {
+	f := func(block SkipBlock) bool {
+		packed, err := block.Pack()
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+
+		pblock := packed.(*blockchain.Block)
+
+		header := &BlockHeaderProto{}
+		err = ptypes.UnmarshalAny(pblock.GetHeader(), header)
+		require.NoError(t, err)
+
+		require.Equal(t, block.Index, pblock.Index)
+		require.Equal(t, block.Height, header.GetHeight())
+		require.Equal(t, block.BaseHeight, header.GetBaseHeight())
+		require.Equal(t, block.MaximumHeight, header.GetMaximumHeight())
+		require.Len(t, header.GetBacklinks(), len(block.BackLinks))
+		require.Len(t, header.GetForwardlinks(), len(block.ForwardLinks))
+		require.Equal(t, block.GenesisID, BlockID(header.GetGenesisID()))
+		require.Equal(t, block.DataHash, header.GetDataHash())
+
+		return true
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func TestSkipBlock_PackFailures(t *testing.T) {
+	defer func() {
+		protoenc = defaultAnyEncoder{}
+	}()
+
+	block := SkipBlock{
+		BackLinks:    []BlockID{{}},
+		ForwardLinks: []ForwardLink{newTestForwardLink()},
+		Payload:      &empty.Empty{},
+	}
+
+	e := xerrors.New("pack error")
+	protoenc = &testAnyEncoder{err: e}
+	_, err := block.Pack()
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, e))
+	require.True(t, xerrors.Is(err, encoding.NewErrAnyEncoding((*BlockHeaderProto)(nil), nil)))
+
+	protoenc = &testAnyEncoder{err: e, delay: 1}
+	_, err = block.Pack()
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, e))
+	require.True(t, xerrors.Is(err, encoding.NewErrAnyEncoding((*empty.Empty)(nil), nil)))
+
+	block.ForwardLinks[0] = testForwardLink{err: e}
+	_, err = block.Pack()
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, e))
+	require.True(t, xerrors.Is(err, encoding.NewErrEncoding("forward link", nil)))
+}
+
+func TestSkipBlock_HashUniqueness(t *testing.T) {
+	// This test will detect any field added in the SkipBlock structure but
+	// not in the hash function. Then it is either added in the hash, or
+	// whitelisted in the test. The field should first be set with a value
+	// different from the zero of the type.
+
+	block := SkipBlock{
+		Index:         1,
+		Roster:        testRoster{buffer: []byte{1}},
+		Height:        1,
+		BaseHeight:    1,
+		MaximumHeight: 1,
+		GenesisID:     []byte{0},
+		DataHash:      []byte{0},
+		BackLinks:     []BlockID{{0}},
+	}
+
+	whitelist := map[string]struct{}{
+		"ForwardLinks": struct{}{},
+		"Payload":      struct{}{},
+	}
+
+	prevHash, err := block.computeHash()
+	require.NoError(t, err)
+
+	value := reflect.ValueOf(&block)
+
+	for i := 0; i < value.Elem().NumField(); i++ {
+		field := value.Elem().Field(i)
+
+		if !field.CanSet() {
+			// ignore private fields.
+			continue
+		}
+
+		fieldName := value.Elem().Type().Field(i).Name
+		if _, ok := whitelist[fieldName]; ok {
+			continue
+		}
+
+		field.Set(reflect.Zero(value.Elem().Field(i).Type()))
+		newBlock := value.Interface()
+
+		hash, err := newBlock.(*SkipBlock).computeHash()
+		require.NoError(t, err)
+
+		errMsg := fmt.Sprintf("field %#v produced same hash", fieldName)
+		require.NotEqual(t, prevHash, hash, errMsg)
+
+		prevHash = hash
+	}
+}
+
+func TestForwardLink_GetFrom(t *testing.T) {
+	f := func(from []byte) bool {
+		fl := forwardLink{from: from}
+
+		return BlockID(from).String() == fl.GetFrom().String()
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func TestForwardLink_GetTo(t *testing.T) {
+	f := func(to []byte) bool {
+		fl := forwardLink{to: to}
+
+		return BlockID(to).String() == fl.GetTo().String()
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func TestForwardLink_Verify(t *testing.T) {
+	fl := forwardLink{
+		hash:    []byte("deadbeef"),
+		prepare: testSignature{buffer: []byte{1}},
+		commit:  testSignature{buffer: []byte{2}},
+	}
+
+	v := &testVerifier{}
+
+	err := fl.Verify(v, nil)
+	require.NoError(t, err)
+	require.Len(t, v.calls, 2)
+	require.Equal(t, fl.hash, v.calls[0].msg)
+	require.Equal(t, fl.prepare, v.calls[0].sig)
+
+	sigbuf, err := fl.prepare.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, sigbuf, v.calls[1].msg)
+	require.Equal(t, fl.commit, v.calls[1].sig)
+}
+
+func TestForwardLink_VerifyFailures(t *testing.T) {
+	fl := forwardLink{
+		prepare: testSignature{},
+		commit:  testSignature{},
+	}
+
+	v := &testVerifier{err: xerrors.New("verify error")}
+
+	err := fl.Verify(v, nil)
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, v.err))
+
+	v.delay = 1
+	err = fl.Verify(v, nil)
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, v.err))
+
+	v.err = nil
+	e := xerrors.New("marshal error")
+	fl.prepare = testSignature{err: e}
+	err = fl.Verify(v, nil)
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, e))
+}
+
+func TestForwardLink_Pack(t *testing.T) {
+	fl := forwardLink{
+		from:    []byte{1, 2, 3},
+		to:      []byte{4, 5, 6},
+		prepare: testSignature{},
+		commit:  testSignature{},
+	}
+
+	packed, err := fl.Pack()
+	require.NoError(t, err)
+
+	flproto := packed.(*ForwardLinkProto)
+
+	require.Equal(t, fl.GetFrom(), BlockID(flproto.GetFrom()))
+	require.Equal(t, fl.GetTo(), BlockID(flproto.GetTo()))
+}
+
+func TestForwardLink_PackFailures(t *testing.T) {
+	fl := forwardLink{}
+
+	e := xerrors.New("sig error")
+	fl.prepare = testSignature{err: e}
+	_, err := fl.Pack()
+	require.Error(t, err)
+	require.True(t, xerrors.Is(err, e))
+}
+
+func TestForwardLink_Hash(t *testing.T) {
+	f := func(from, to []byte) bool {
+		fl := forwardLink{from: from, to: to}
+		hash, err := fl.computeHash()
+		require.NoError(t, err)
+
+		// It is enough for the forward links to have From and To in the hash
+		// as the integrity of the block is then verified.
+		h := sha256.New()
+		h.Write(from)
+		h.Write(to)
+		return bytes.Equal(hash, h.Sum(nil))
+	}
+
+	err := quick.Check(f, nil)
+	require.NoError(t, err)
+}
+
+func randomUint64(rand *rand.Rand) uint64 {
+	buffer := make([]byte, 16)
+	rand.Read(buffer)
+	return binary.LittleEndian.Uint64(buffer)
+}
+
+func randomUint32(rand *rand.Rand) uint32 {
+	buffer := make([]byte, 8)
+	rand.Read(buffer)
+	return binary.LittleEndian.Uint32(buffer)
+}
+
+func (s SkipBlock) Generate(rand *rand.Rand, size int) reflect.Value {
+	genesisID := make([]byte, size)
+	rand.Read(genesisID)
+
+	dataHash := make([]byte, size)
+	rand.Read(dataHash)
+
+	backlinks := make([]BlockID, rand.Int31n(int32(size)))
+	for i := range backlinks {
+		backlinks[i] = make([]byte, 32)
+		rand.Read(backlinks[i])
+	}
+
+	forwardlinks := make([]ForwardLink, rand.Int31n(int32(size)))
+	for i := range forwardlinks {
+		forwardlinks[i] = forwardLink{}
+	}
+
+	block := SkipBlock{
+		Index:         randomUint64(rand),
+		Height:        randomUint32(rand),
+		BaseHeight:    randomUint32(rand),
+		MaximumHeight: randomUint32(rand),
+		Roster:        blockchain.SimpleRoster{},
+		GenesisID:     genesisID,
+		DataHash:      dataHash,
+		BackLinks:     []BlockID{{1}},
+		ForwardLinks:  forwardlinks,
+		Payload:       &empty.Empty{},
+	}
+
+	return reflect.ValueOf(block)
+}
+
+type testRoster struct {
+	buffer []byte
+}
+
+func (r testRoster) GetConodes() []*blockchain.Conode {
+	return nil
+}
+
+func (r testRoster) GetAddresses() []*mino.Address {
+	return nil
+}
+
+func (r testRoster) GetPublicKeys() []crypto.PublicKey {
+	return nil
+}
+
+func (r testRoster) WriteTo(w io.Writer) (int64, error) {
+	w.Write(r.buffer)
+	return int64(len(r.buffer)), nil
+}
+
+type testAnyEncoder struct {
+	delay int
+	err   error
+}
+
+func (e *testAnyEncoder) MarshalAny(pb proto.Message) (*any.Any, error) {
+	if e.err != nil {
+		if e.delay == 0 {
+			return nil, e.err
+		}
+
+		e.delay--
+	}
+
+	return ptypes.MarshalAny(pb)
+}
+
+func (e *testAnyEncoder) UnmarshalAny(any *any.Any, pb proto.Message) error {
+	if e.err != nil {
+		return e.err
+	}
+
+	return ptypes.UnmarshalAny(any, pb)
+}
+
+type testForwardLink struct {
+	forwardLink
+	err error
+}
+
+func newTestForwardLink() testForwardLink {
+	return testForwardLink{
+		forwardLink: forwardLink{
+			from: []byte{1},
+			to:   []byte{2},
+		},
+	}
+}
+
+func (fl testForwardLink) Pack() (proto.Message, error) {
+	if fl.err != nil {
+		return nil, fl.err
+	}
+
+	return fl.forwardLink.Pack()
+}
+
+type testSignature struct {
+	buffer []byte
+	err    error
+}
+
+func (s testSignature) MarshalBinary() ([]byte, error) {
+	return s.buffer, s.err
+}
+
+func (s testSignature) Pack() (proto.Message, error) {
+	return &empty.Empty{}, s.err
+}
+
+type testVerifier struct {
+	err   error
+	delay int
+	calls []struct {
+		msg []byte
+		sig crypto.Signature
+	}
+
+	crypto.Verifier
+}
+
+func (v *testVerifier) Verify(pubkeys []crypto.PublicKey, msg []byte, sig crypto.Signature) error {
+	v.calls = append(v.calls, struct {
+		msg []byte
+		sig crypto.Signature
+	}{msg, sig})
+
+	if v.err != nil {
+		if v.delay == 0 {
+			return v.err
+		}
+		v.delay--
+	}
+
+	return nil
+}

--- a/blockchain/skipchain/block_test.go
+++ b/blockchain/skipchain/block_test.go
@@ -408,7 +408,7 @@ func TestProof_VerifyFailures(t *testing.T) {
 	proof.GenesisBlock = SkipBlock{hash: []byte{0xaa}, Roster: testRoster{}}
 	err = proof.Verify(&testVerifier{}, SkipBlock{})
 	require.Error(t, err)
-	require.EqualError(t, xerrors.Unwrap(err), "got previous block 01 but expect aa in forward link")
+	require.EqualError(t, xerrors.Unwrap(err), "got previous block '01' but expected 'aa' in forward link")
 
 	proof.ForwardLinks = []ForwardLink{
 		forwardLink{from: []byte{0xaa}, to: []byte{0xbb}, prepare: testSignature{}, commit: testSignature{}},
@@ -416,14 +416,14 @@ func TestProof_VerifyFailures(t *testing.T) {
 	}
 	err = proof.Verify(&testVerifier{}, SkipBlock{})
 	require.Error(t, err)
-	require.EqualError(t, xerrors.Unwrap(err), "got previous block cc but expect bb in forward link")
+	require.EqualError(t, xerrors.Unwrap(err), "got previous block 'cc' but expected 'bb' in forward link")
 
 	proof.ForwardLinks = []ForwardLink{
 		forwardLink{from: []byte{0xaa}, to: []byte{0xbb}, prepare: testSignature{}, commit: testSignature{}},
 	}
 	err = proof.Verify(&testVerifier{}, SkipBlock{hash: []byte{0xcc}})
 	require.Error(t, err)
-	require.EqualError(t, err, "got forward link to bb but expect cc")
+	require.EqualError(t, err, "got forward link to 'bb' but expected 'cc'")
 }
 
 func TestBlockFactory_CreateGenesis(t *testing.T) {

--- a/blockchain/skipchain/handler.go
+++ b/blockchain/skipchain/handler.go
@@ -42,7 +42,7 @@ func (h handler) Process(req proto.Message) (proto.Message, error) {
 			return nil, xerrors.Errorf("couldn't decode the forward link: %v", err)
 		}
 
-		err = h.triage.Commit(fl)
+		err = h.triage.Commit(fl.(forwardLink))
 		if err != nil {
 			return nil, xerrors.Errorf("couldn't commit the forward link: %v", err)
 		}

--- a/blockchain/skipchain/mod.go
+++ b/blockchain/skipchain/mod.go
@@ -127,7 +127,7 @@ func (s *Skipchain) Store(roster blockchain.Roster, data proto.Message) error {
 	return nil
 }
 
-func (s *Skipchain) pbft(block SkipBlock) (*ForwardLink, error) {
+func (s *Skipchain) pbft(block SkipBlock) (*forwardLink, error) {
 	// 1. Prepare phase
 	// The block is sent for validation and participants will return a signature
 	// to confirm they agree the proposal is valid.
@@ -147,10 +147,10 @@ func (s *Skipchain) pbft(block SkipBlock) (*ForwardLink, error) {
 	// participants will sign their commitment to the block after verifying
 	// that the prepare signature is correct.
 	// Signature = Sign(PREPARE_SIG)
-	fl := &ForwardLink{
-		From:    block.BackLinks[0],
-		To:      block.hash,
-		Prepare: sig,
+	fl := &forwardLink{
+		from:    block.BackLinks[0],
+		to:      block.hash,
+		prepare: sig,
 	}
 
 	packed, err := fl.Pack()
@@ -163,7 +163,7 @@ func (s *Skipchain) pbft(block SkipBlock) (*ForwardLink, error) {
 		return nil, xerrors.Errorf("couldn't sign the forward link: %v", err)
 	}
 
-	fl.Commit = sig
+	fl.commit = sig
 
 	return fl, nil
 }

--- a/blockchain/skipchain/validator.go
+++ b/blockchain/skipchain/validator.go
@@ -60,9 +60,9 @@ func (b *blockValidator) verifyAndHashBlock(in *blockchain.Block) ([]byte, error
 		return nil, xerrors.Errorf("couldn't add the block to the triage: %v", err)
 	}
 
-	fl := ForwardLink{
-		From: block.BackLinks[0],
-		To:   block.hash,
+	fl := forwardLink{
+		from: block.BackLinks[0],
+		to:   block.hash,
 	}
 
 	hash, err := fl.computeHash()
@@ -79,14 +79,16 @@ func (b *blockValidator) verifyAndHashForwardLink(in *ForwardLinkProto) ([]byte,
 		return nil, xerrors.Errorf("couldn't decode the forward link: %v", err)
 	}
 
+	forwardLink := fl.(forwardLink)
+
 	// Verify that the triage has a block waiting to be committed and that the
 	// forward link is matching correctly.
-	err = b.triage.Verify(fl)
+	err = b.triage.Verify(forwardLink)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't verify the block in triage: %v", err)
 	}
 
-	buffer, err := fl.Prepare.MarshalBinary()
+	buffer, err := forwardLink.prepare.MarshalBinary()
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't marshal the prepare signature: %v", err)
 	}

--- a/cosi/blscosi/mod.go
+++ b/cosi/blscosi/mod.go
@@ -77,7 +77,7 @@ func (cosi *BlsCoSi) Sign(ro blockchain.Roster, msg proto.Message) (crypto.Signa
 			fabric.Logger.Trace().Msgf("Response: %+v", resp)
 
 			reply := resp.(*SignatureResponse)
-			sig, err := cosi.signer.GetSignatureFactory().FromAny(reply.GetSignature())
+			sig, err := cosi.signer.GetSignatureFactory().FromProto(reply.GetSignature())
 			if err != nil {
 				return nil, err
 			}

--- a/crypto/bls/mod.go
+++ b/crypto/bls/mod.go
@@ -64,14 +64,14 @@ func (f publicKeyFactory) FromProto(src proto.Message) (crypto.PublicKey, error)
 		point := suite.Point()
 		err := point.UnmarshalBinary(msg.GetData())
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("failed to unmarshal msg to point: %v", err)
 		}
 
 		return publicKey{point: point}, nil
 	case *any.Any:
 		return f.fromAny(msg)
 	default:
-		return nil, errors.New("invalid public key type")
+		return nil, xerrors.Errorf("invalid public key type '%v'", msg)
 	}
 }
 
@@ -94,7 +94,7 @@ func (f signatureFactory) FromProto(src proto.Message) (crypto.Signature, error)
 	case *any.Any:
 		return f.FromAny(msg)
 	default:
-		return nil, errors.New("invalid signature type")
+		return nil, xerrors.Errorf("invalid signature type '%v'", msg)
 	}
 }
 

--- a/crypto/bls/mod.go
+++ b/crypto/bls/mod.go
@@ -1,8 +1,6 @@
 package bls
 
 import (
-	"errors"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -11,6 +9,7 @@ import (
 	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/kyber/v3/sign/bls"
 	"go.dedis.ch/kyber/v3/util/key"
+	"golang.org/x/xerrors"
 )
 
 //go:generate protoc -I ./ --go_out=./ ./messages.proto

--- a/crypto/mod.go
+++ b/crypto/mod.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	"go.dedis.ch/fabric/encoding"
 )
 
@@ -14,7 +13,6 @@ type PublicKey interface {
 
 // PublicKeyFactory is a factory to create public keys.
 type PublicKeyFactory interface {
-	FromAny(src *any.Any) (PublicKey, error)
 	FromProto(src proto.Message) (PublicKey, error)
 }
 
@@ -26,7 +24,6 @@ type Signature interface {
 
 // SignatureFactory is a factory to create BLS signature.
 type SignatureFactory interface {
-	FromAny(src *any.Any) (Signature, error)
 	FromProto(src proto.Message) (Signature, error)
 }
 

--- a/crypto/mod.go
+++ b/crypto/mod.go
@@ -9,6 +9,7 @@ import (
 // PublicKey is a public identity that can be used to verify a signature.
 type PublicKey interface {
 	encoding.Packable
+	encoding.BinaryMarshaler
 }
 
 // PublicKeyFactory is a factory to create public keys.
@@ -20,6 +21,7 @@ type PublicKeyFactory interface {
 // Signature is a verifiable element for a unique message.
 type Signature interface {
 	encoding.Packable
+	encoding.BinaryMarshaler
 }
 
 // SignatureFactory is a factory to create BLS signature.

--- a/encoding/errors.go
+++ b/encoding/errors.go
@@ -1,0 +1,60 @@
+package encoding
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type ErrEncoding struct {
+	Field string
+	Err   error
+}
+
+func NewErrEncoding(field string, err error) ErrEncoding {
+	return ErrEncoding{
+		Field: field,
+		Err:   err,
+	}
+}
+
+func (e ErrEncoding) Error() string {
+	return fmt.Sprintf("couldn't encode %s", e.Field)
+}
+
+func (e ErrEncoding) Is(err error) bool {
+	errenc, ok := err.(ErrEncoding)
+
+	return ok && errenc.Field == e.Field
+}
+
+func (e ErrEncoding) Unwrap() error {
+	return e.Err
+}
+
+type ErrAnyEncoding struct {
+	Message proto.Message
+	Err     error
+}
+
+func NewErrAnyEncoding(msg proto.Message, err error) ErrAnyEncoding {
+	return ErrAnyEncoding{
+		Message: msg,
+		Err:     err,
+	}
+}
+
+func (e ErrAnyEncoding) Error() string {
+	return fmt.Sprintf("couldn't marshal %s to any", e.Message)
+}
+
+func (e ErrAnyEncoding) Is(err error) bool {
+	errenc, ok := err.(ErrAnyEncoding)
+
+	return ok && reflect.TypeOf(errenc.Message).Kind() == reflect.TypeOf(e.Message).Kind()
+}
+
+func (e ErrAnyEncoding) Unwrap() error {
+	return e.Err
+}

--- a/encoding/errors.go
+++ b/encoding/errors.go
@@ -115,7 +115,7 @@ func NewTypeError(curr proto.Message, expected proto.Message) TypeError {
 }
 
 func (e TypeError) Error() string {
-	return fmt.Sprintf("got message type %#v but expect %#v", e.curr, e.expected)
+	return fmt.Sprintf("got message type '%#v' but expected '%#v'", e.curr, e.expected)
 }
 
 func (e TypeError) Is(err error) bool {

--- a/encoding/errors.go
+++ b/encoding/errors.go
@@ -7,54 +7,119 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-type ErrEncoding struct {
+type errType string
+
+const (
+	errTypeEncoding = errType("encode")
+	errTypeDecoding = errType("decode")
+)
+
+// Error is the kind of error to return when there is an encoding/decoding issue.
+type Error struct {
+	key   errType
 	Field string
 	Err   error
 }
 
-func NewErrEncoding(field string, err error) ErrEncoding {
-	return ErrEncoding{
+// NewEncodingError creates a new error for an encoding failure.
+func NewEncodingError(field string, err error) Error {
+	return Error{
+		key:   errTypeEncoding,
 		Field: field,
 		Err:   err,
 	}
 }
 
-func (e ErrEncoding) Error() string {
-	return fmt.Sprintf("couldn't encode %s", e.Field)
+// NewDecodingError creates a new error for a decoding failure.
+func NewDecodingError(field string, err error) Error {
+	return Error{
+		key:   errTypeDecoding,
+		Field: field,
+		Err:   err,
+	}
 }
 
-func (e ErrEncoding) Is(err error) bool {
-	errenc, ok := err.(ErrEncoding)
-
-	return ok && errenc.Field == e.Field
+func (e Error) Error() string {
+	return fmt.Sprintf("couldn't %s %s", e.key, e.Field)
 }
 
-func (e ErrEncoding) Unwrap() error {
+// Is returns true when both errors are similar.
+func (e Error) Is(err error) bool {
+	errenc, ok := err.(Error)
+
+	return ok && e.key == errenc.key && errenc.Field == e.Field
+}
+
+// Unwrap returns the error wrapped.
+func (e Error) Unwrap() error {
 	return e.Err
 }
 
-type ErrAnyEncoding struct {
+// AnyError is the kind of error to return when there is an encoding/decoding
+// failure when marshaling/unmarshaling to any.
+type AnyError struct {
+	key     errType
 	Message proto.Message
 	Err     error
 }
 
-func NewErrAnyEncoding(msg proto.Message, err error) ErrAnyEncoding {
-	return ErrAnyEncoding{
+// NewAnyEncodingError creates an error for a marshaling failure.
+func NewAnyEncodingError(msg proto.Message, err error) AnyError {
+	return AnyError{
+		key:     errTypeEncoding,
 		Message: msg,
 		Err:     err,
 	}
 }
 
-func (e ErrAnyEncoding) Error() string {
-	return fmt.Sprintf("couldn't marshal %s to any", e.Message)
+// NewAnyDecodingError creates an error for a unmarshaling failure.
+func NewAnyDecodingError(msg proto.Message, err error) AnyError {
+	return AnyError{
+		key:     errTypeDecoding,
+		Message: msg,
+		Err:     err,
+	}
 }
 
-func (e ErrAnyEncoding) Is(err error) bool {
-	errenc, ok := err.(ErrAnyEncoding)
-
-	return ok && reflect.TypeOf(errenc.Message).Kind() == reflect.TypeOf(e.Message).Kind()
+func (e AnyError) Error() string {
+	msgType := reflect.TypeOf(e.Message)
+	return fmt.Sprintf("couldn't %s %v to any: %v", e.key, msgType, e.Err)
 }
 
-func (e ErrAnyEncoding) Unwrap() error {
+// Is returns true when both errors are similar.
+func (e AnyError) Is(err error) bool {
+	errenc, ok := err.(AnyError)
+
+	return ok && e.key == errenc.key &&
+		reflect.TypeOf(errenc.Message) == reflect.TypeOf(e.Message)
+}
+
+// Unwrap returns the error wrapped.
+func (e AnyError) Unwrap() error {
 	return e.Err
+}
+
+type TypeError struct {
+	curr     string
+	expected string
+}
+
+func NewTypeError(curr proto.Message, expected proto.Message) TypeError {
+	currType := reflect.TypeOf(curr)
+	expectedType := reflect.TypeOf(expected)
+
+	return TypeError{
+		curr:     currType.String(),
+		expected: expectedType.String(),
+	}
+}
+
+func (e TypeError) Error() string {
+	return fmt.Sprintf("got message type %#v but expect %#v", e.curr, e.expected)
+}
+
+func (e TypeError) Is(err error) bool {
+	errtype, ok := err.(TypeError)
+
+	return ok && errtype.curr == e.curr && errtype.expected == e.expected
 }

--- a/encoding/mod.go
+++ b/encoding/mod.go
@@ -4,12 +4,22 @@ import (
 	"encoding"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 // Packable is an interface that provides primitives to pack data model into
 // network messages.
 type Packable interface {
-	encoding.BinaryMarshaler
-
 	Pack() (proto.Message, error)
+}
+
+// BinaryMarshaler is an alias of the standard encoding library.
+type BinaryMarshaler interface {
+	encoding.BinaryMarshaler
+}
+
+// AnyMarshaler is an interface to encode or decode Any messages.
+type AnyMarshaler interface {
+	MarshalAny(pb proto.Message) (*any.Any, error)
+	UnmarshalAny(any *any.Any, pb proto.Message) error
 }

--- a/encoding/mod.go
+++ b/encoding/mod.go
@@ -18,8 +18,9 @@ type BinaryMarshaler interface {
 	encoding.BinaryMarshaler
 }
 
-// AnyMarshaler is an interface to encode or decode Any messages.
-type AnyMarshaler interface {
+// ProtoMarshaler is an interface to encode or decode Any messages.
+type ProtoMarshaler interface {
+	Marshal(pb proto.Message) ([]byte, error)
 	MarshalAny(pb proto.Message) (*any.Any, error)
 	UnmarshalAny(any *any.Any, pb proto.Message) error
 }

--- a/mod.go
+++ b/mod.go
@@ -16,4 +16,4 @@ var logout = zerolog.ConsoleWriter{
 var Logger = zerolog.New(logout).
 	With().Timestamp().Logger().
 	With().Caller().Logger().
-	Level(zerolog.DebugLevel)
+	Level(zerolog.InfoLevel)


### PR DESCRIPTION
This aims to add unit test to the skipchain module. This is a first wave before extracting the consensus module logic. After that the final coverage will be done.