### PR TITLE
Skipchain: atomic commit

### DIFF
--- a/blockchain/skipchain/db_test.go
+++ b/blockchain/skipchain/db_test.go
@@ -1,0 +1,76 @@
+package skipchain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryDatabase_Write(t *testing.T) {
+	db := NewInMemoryDatabase()
+
+	err := db.Write(SkipBlock{})
+	require.NoError(t, err)
+
+	err = db.Write(SkipBlock{Index: 1})
+	require.NoError(t, err)
+
+	err = db.Write(SkipBlock{Index: 1})
+	require.NoError(t, err)
+
+	err = db.Write(SkipBlock{Index: 5})
+	require.EqualError(t, err, "missing intermediate blocks for index 5")
+}
+
+func TestInMemoryDatabase_Read(t *testing.T) {
+	db := NewInMemoryDatabase()
+	db.blocks = []SkipBlock{
+		{Index: 0},
+		{Index: 1},
+	}
+
+	block, err := db.Read(1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), block.Index)
+
+	_, err = db.Read(5)
+	require.EqualError(t, err, "block at index 5 not found")
+}
+
+func TestInMemoryDatabase_ReadLast(t *testing.T) {
+	db := NewInMemoryDatabase()
+	db.blocks = []SkipBlock{
+		{Index: 0},
+		{Index: 1},
+	}
+
+	block, err := db.ReadLast()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), block.Index)
+
+	db.blocks = append(db.blocks, SkipBlock{Index: 2})
+	block, err = db.ReadLast()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), block.Index)
+
+	db.blocks = nil
+	_, err = db.ReadLast()
+	require.EqualError(t, err, "database is empty")
+}
+
+func TestInMemoryDatabase_Atomic(t *testing.T) {
+	db := NewInMemoryDatabase()
+
+	err := db.Atomic(func(ops Queries) error {
+		return ops.Write(SkipBlock{Index: 0})
+	})
+	require.NoError(t, err)
+	require.Len(t, db.blocks, 1)
+
+	err = db.Atomic(func(ops Queries) error {
+		return ops.Write(SkipBlock{Index: 2})
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't execute transaction: ")
+	require.Len(t, db.blocks, 1)
+}

--- a/blockchain/skipchain/handler_test.go
+++ b/blockchain/skipchain/handler_test.go
@@ -12,7 +12,7 @@ import (
 func TestHandler_Process(t *testing.T) {
 	f := func(block SkipBlock) bool {
 		h := newHandler(&Skipchain{
-			db:        fakeDatabase{},
+			db:        &fakeDatabase{},
 			cosi:      fakeCosi{},
 			mino:      fakeMino{},
 			consensus: fakeConsensus{},
@@ -32,7 +32,7 @@ func TestHandler_Process(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "couldn't decode the block: ")
 
-		h.Skipchain.db = fakeDatabase{err: xerrors.New("oops")}
+		h.Skipchain.db = &fakeDatabase{err: xerrors.New("oops")}
 		_, err = h.Process(&PropagateGenesis{Genesis: packed.(*BlockProto)})
 		require.EqualError(t, err, "couldn't write the block: oops")
 

--- a/blockchain/skipchain/mod_test.go
+++ b/blockchain/skipchain/mod_test.go
@@ -90,14 +90,14 @@ func TestSkipchain_Listen(t *testing.T) {
 func TestSkipchain_GetBlock(t *testing.T) {
 	digest := Digest{1, 2, 3}
 	s := &Skipchain{
-		db: fakeDatabase{genesisID: digest},
+		db: &fakeDatabase{genesisID: digest},
 	}
 
 	block, err := s.GetBlock()
 	require.NoError(t, err)
 	require.Equal(t, digest, block.(SkipBlock).hash)
 
-	s.db = fakeDatabase{err: xerrors.New("oops")}
+	s.db = &fakeDatabase{err: xerrors.New("oops")}
 	_, err = s.GetBlock()
 	require.EqualError(t, err, "couldn't read the latest block: oops")
 }
@@ -105,7 +105,7 @@ func TestSkipchain_GetBlock(t *testing.T) {
 func TestSkipchain_GetVerifiableBlock(t *testing.T) {
 	digest := Digest{1, 2, 3}
 	s := &Skipchain{
-		db:        fakeDatabase{genesisID: digest},
+		db:        &fakeDatabase{genesisID: digest},
 		consensus: fakeConsensus{},
 	}
 
@@ -114,11 +114,11 @@ func TestSkipchain_GetVerifiableBlock(t *testing.T) {
 	require.Equal(t, digest, block.(VerifiableBlock).hash)
 	require.NotNil(t, block.(VerifiableBlock).Chain)
 
-	s.db = fakeDatabase{err: xerrors.New("oops")}
+	s.db = &fakeDatabase{err: xerrors.New("oops")}
 	_, err = s.GetVerifiableBlock()
 	require.EqualError(t, err, "couldn't read the latest block: oops")
 
-	s.db = fakeDatabase{}
+	s.db = &fakeDatabase{}
 	s.consensus = fakeConsensus{err: xerrors.New("oops")}
 	_, err = s.GetVerifiableBlock()
 	require.EqualError(t, err, "couldn't read the chain: oops")
@@ -145,7 +145,7 @@ func TestActor_InitChain(t *testing.T) {
 	actor := skipchainActor{
 		hashFactory: sha256Factory{},
 		Skipchain: &Skipchain{
-			db: fakeDatabase{},
+			db: &fakeDatabase{},
 		},
 		rpc: fakeRPC{},
 	}
@@ -162,11 +162,11 @@ func TestActor_InitChain(t *testing.T) {
 	require.Contains(t, err.Error(), "couldn't create block: ")
 
 	actor.hashFactory = sha256Factory{}
-	actor.Skipchain.db = fakeDatabase{err: xerrors.New("oops")}
+	actor.Skipchain.db = &fakeDatabase{err: xerrors.New("oops")}
 	err = actor.InitChain(&empty.Empty{}, Conodes{})
 	require.EqualError(t, err, "couldn't write genesis block: oops")
 
-	actor.Skipchain.db = fakeDatabase{}
+	actor.Skipchain.db = &fakeDatabase{}
 	actor.rpc = fakeRPC{err: xerrors.New("oops")}
 	err = actor.InitChain(&empty.Empty{}, Conodes{})
 	require.EqualError(t, err, "couldn't propagate: oops")
@@ -175,7 +175,7 @@ func TestActor_InitChain(t *testing.T) {
 func TestActor_Store(t *testing.T) {
 	actor := skipchainActor{
 		Skipchain: &Skipchain{
-			db: fakeDatabase{},
+			db: &fakeDatabase{},
 		},
 		consensus: fakeConsensusActor{},
 	}
@@ -183,11 +183,11 @@ func TestActor_Store(t *testing.T) {
 	err := actor.Store(&empty.Empty{}, Conodes{})
 	require.NoError(t, err)
 
-	actor.Skipchain.db = fakeDatabase{err: xerrors.New("oops")}
+	actor.Skipchain.db = &fakeDatabase{err: xerrors.New("oops")}
 	err = actor.Store(&empty.Empty{}, Conodes{})
 	require.EqualError(t, err, "couldn't read the latest block: oops")
 
-	actor.Skipchain.db = fakeDatabase{}
+	actor.Skipchain.db = &fakeDatabase{}
 	actor.consensus = fakeConsensusActor{err: xerrors.New("oops")}
 	err = actor.Store(&empty.Empty{}, Conodes{})
 	require.EqualError(t, err, "couldn't propose the block: oops")


### PR DESCRIPTION
This implements an atomic commit so that the upper layer can fail without the block to be written in the database.